### PR TITLE
Fixed deadlock on concurrent closing

### DIFF
--- a/session.go
+++ b/session.go
@@ -121,13 +121,14 @@ func (s *Session) AcceptStream() (*Stream, error) {
 // Close is used to close the session and all streams.
 func (s *Session) Close() (err error) {
 	s.dieLock.Lock()
-	defer s.dieLock.Unlock()
 
 	select {
 	case <-s.die:
+		s.dieLock.Unlock()
 		return errors.New(errBrokenPipe)
 	default:
 		close(s.die)
+		s.dieLock.Unlock()
 		s.streamLock.Lock()
 		for k := range s.streams {
 			s.streams[k].sessionClose()

--- a/stream.go
+++ b/stream.go
@@ -126,13 +126,14 @@ func (s *Stream) Write(b []byte) (n int, err error) {
 // Close implements io.ReadWriteCloser
 func (s *Stream) Close() error {
 	s.dieLock.Lock()
-	defer s.dieLock.Unlock()
 
 	select {
 	case <-s.die:
+		s.dieLock.Unlock()
 		return errors.New(errBrokenPipe)
 	default:
 		close(s.die)
+		s.dieLock.Unlock()
 		s.sess.streamClosed(s.id)
 		_, err := s.sess.writeFrame(newFrame(cmdRST, s.id))
 		return err


### PR DESCRIPTION
At [getlantern/lantern](https://github.com/getlantern/lantern) we noticed that sometimes there was a deadlock when closing sessions/streams. This adds a test that reproduces the deadlock and a code fix for the deadlock.