### PR TITLE
add token into stream

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -14,6 +14,7 @@ const ( // cmds
 	cmdFIN             // stream close, a.k.a EOF mark
 	cmdPSH             // data push
 	cmdNOP             // no operation
+	cmdACK             // for test RTT
 	cmdFUL             // buffer full
 	cmdEMP             // buffer empty
 )

--- a/frame.go
+++ b/frame.go
@@ -14,6 +14,8 @@ const ( // cmds
 	cmdFIN             // stream close, a.k.a EOF mark
 	cmdPSH             // data push
 	cmdNOP             // no operation
+	cmdFUL             // buffer full
+	cmdEMP             // buffer empty
 )
 
 const (

--- a/mux.go
+++ b/mux.go
@@ -25,6 +25,9 @@ type Config struct {
 	// number of data in the buffer pool
 	MaxReceiveBuffer int
 
+	// Enable Stream buffer
+	EnableStreamBuffer bool
+
 	// maximum bytes that each Stream can use
 	MaxStreamBuffer int
 
@@ -35,12 +38,13 @@ type Config struct {
 // DefaultConfig is used to return a default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		KeepAliveInterval: 10 * time.Second,
-		KeepAliveTimeout:  30 * time.Second,
-		MaxFrameSize:      4096,
-		MaxReceiveBuffer:  16 * 1024 * 1024,
-		MaxStreamBuffer:   16384,
-		MinStreamBuffer:   4096,
+		KeepAliveInterval:  10 * time.Second,
+		KeepAliveTimeout:   30 * time.Second,
+		MaxFrameSize:       4096,
+		MaxReceiveBuffer:   16 * 1024 * 1024,
+		EnableStreamBuffer: false,
+		MaxStreamBuffer:    16384,
+		MinStreamBuffer:    4096,
 	}
 }
 
@@ -65,7 +69,7 @@ func VerifyConfig(config *Config) error {
 		return errors.New("max stream receive buffer must be positive")
 	}
 	if config.MinStreamBuffer < 0 || config.MinStreamBuffer > config.MaxStreamBuffer {
-		return errors.New("max stream receive buffer must be positive and <= MaxStreamBuffer")
+		return errors.New("min stream receive buffer must be positive and <= MaxStreamBuffer")
 	}
 	return nil
 }

--- a/mux.go
+++ b/mux.go
@@ -33,6 +33,9 @@ type Config struct {
 
 	// send cmdEMP earlier when remain ?? bytes data in buffer
 	MinStreamBuffer int
+
+	// for initial boost (ms)
+	BoostTimeout int
 }
 
 // DefaultConfig is used to return a default configuration
@@ -45,6 +48,7 @@ func DefaultConfig() *Config {
 		EnableStreamBuffer: false,
 		MaxStreamBuffer:    16384,
 		MinStreamBuffer:    4096,
+		BoostTimeout:       10 * 1000,
 	}
 }
 

--- a/mux.go
+++ b/mux.go
@@ -34,8 +34,8 @@ type Config struct {
 	// send cmdEMP earlier when remain ?? bytes data in buffer
 	MinStreamBuffer int
 
-	// for initial boost (ms)
-	BoostTimeout int
+	// for initial boost
+	BoostTimeout time.Duration
 }
 
 // DefaultConfig is used to return a default configuration
@@ -48,7 +48,7 @@ func DefaultConfig() *Config {
 		EnableStreamBuffer: false,
 		MaxStreamBuffer:    16384,
 		MinStreamBuffer:    4096,
-		BoostTimeout:       10 * 1000,
+		BoostTimeout:       10 * time.Second,
 	}
 }
 

--- a/mux.go
+++ b/mux.go
@@ -31,9 +31,6 @@ type Config struct {
 	// maximum bytes that each Stream can use
 	MaxStreamBuffer int
 
-	// send cmdEMP earlier when remain ?? bytes data in buffer
-	MinStreamBuffer int
-
 	// for initial boost
 	BoostTimeout time.Duration
 }
@@ -46,8 +43,7 @@ func DefaultConfig() *Config {
 		MaxFrameSize:       4096,
 		MaxReceiveBuffer:   16 * 1024 * 1024,
 		EnableStreamBuffer: false,
-		MaxStreamBuffer:    16384,
-		MinStreamBuffer:    4096,
+		MaxStreamBuffer:    1024 * 1024,
 		BoostTimeout:       10 * time.Second,
 	}
 }
@@ -71,9 +67,6 @@ func VerifyConfig(config *Config) error {
 	}
 	if config.MaxStreamBuffer <= 0 {
 		return errors.New("max stream receive buffer must be positive")
-	}
-	if config.MinStreamBuffer < 0 || config.MinStreamBuffer > config.MaxStreamBuffer {
-		return errors.New("min stream receive buffer must be positive and <= MaxStreamBuffer")
 	}
 	return nil
 }

--- a/mux.go
+++ b/mux.go
@@ -24,6 +24,12 @@ type Config struct {
 	// MaxReceiveBuffer is used to control the maximum
 	// number of data in the buffer pool
 	MaxReceiveBuffer int
+
+	// maximum bytes that each Stream can use
+	MaxStreamBuffer int
+
+	// send cmdEMP earlier when remain ?? bytes data in buffer
+	MinStreamBuffer int
 }
 
 // DefaultConfig is used to return a default configuration
@@ -32,7 +38,9 @@ func DefaultConfig() *Config {
 		KeepAliveInterval: 10 * time.Second,
 		KeepAliveTimeout:  30 * time.Second,
 		MaxFrameSize:      4096,
-		MaxReceiveBuffer:  4194304,
+		MaxReceiveBuffer:  16 * 1024 * 1024,
+		MaxStreamBuffer:   16384,
+		MinStreamBuffer:   4096,
 	}
 }
 
@@ -52,6 +60,12 @@ func VerifyConfig(config *Config) error {
 	}
 	if config.MaxReceiveBuffer <= 0 {
 		return errors.New("max receive buffer must be positive")
+	}
+	if config.MaxStreamBuffer <= 0 {
+		return errors.New("max stream receive buffer must be positive")
+	}
+	if config.MinStreamBuffer < 0 || config.MinStreamBuffer > config.MaxStreamBuffer {
+		return errors.New("max stream receive buffer must be positive and <= MaxStreamBuffer")
 	}
 	return nil
 }

--- a/session.go
+++ b/session.go
@@ -77,7 +77,7 @@ func newSession(config *Config, conn io.ReadWriteCloser, client bool) *Session {
 	s.MaxReceiveBuffer = config.MaxReceiveBuffer
 	s.MaxStreamBuffer = config.MaxStreamBuffer
 	s.MinStreamBuffer = config.MinStreamBuffer
-	s.BoostTimeout = time.Duration(config.BoostTimeout) * time.Millisecond
+	s.BoostTimeout = config.BoostTimeout
 
 	s.EnableStreamBuffer = config.EnableStreamBuffer
 

--- a/session.go
+++ b/session.go
@@ -56,8 +56,11 @@ type Session struct {
 
 	writes chan writeRequest
 
+	EnableStreamBuffer bool
+	MaxReceiveBuffer int
 	MaxStreamBuffer int
 	MinStreamBuffer int
+	BoostTimeout time.Duration
 }
 
 func newSession(config *Config, conn io.ReadWriteCloser, client bool) *Session {
@@ -71,14 +74,12 @@ func newSession(config *Config, conn io.ReadWriteCloser, client bool) *Session {
 	s.bucketNotify = make(chan struct{}, 1)
 	s.writes = make(chan writeRequest)
 
+	s.MaxReceiveBuffer = config.MaxReceiveBuffer
 	s.MaxStreamBuffer = config.MaxStreamBuffer
-	s.MinStreamBuffer = config.MaxStreamBuffer - config.MinStreamBuffer
+	s.MinStreamBuffer = config.MinStreamBuffer
+	s.BoostTimeout = time.Duration(config.BoostTimeout) * time.Millisecond
 
-	if !config.EnableStreamBuffer {
-		// StreamBuffer > config.MaxReceiveBuffer to disable
-		s.MaxStreamBuffer = 0x7fff0000 // ~2048GB
-		s.MinStreamBuffer = 0x7fff0000
-	}
+	s.EnableStreamBuffer = config.EnableStreamBuffer
 
 	if client {
 		s.nextStreamID = 1

--- a/session_test.go
+++ b/session_test.go
@@ -561,7 +561,6 @@ func TestSlowReadBlocking(t *testing.T) {
 		MaxReceiveBuffer:   1 * 1024 * 1024,
 		EnableStreamBuffer: true,
 		MaxStreamBuffer:    16384,
-		MinStreamBuffer:    4096,
 		BoostTimeout:       100 * time.Millisecond,
 	}
 
@@ -628,7 +627,7 @@ func TestSlowReadBlocking(t *testing.T) {
 			const SIZE = 4 * 1024 // 4KB
 
 			var fwg sync.WaitGroup
-			/*fwg.Add(1)
+			fwg.Add(1)
 			go func() { // read = 4 * 2000 KB/s
 				defer fwg.Done()
 				rbuf := make([]byte, SIZE, SIZE)
@@ -641,9 +640,9 @@ func TestSlowReadBlocking(t *testing.T) {
 						}
 						break
 					}
-					<- time.After(200 * time.Microsecond) // slow down read
+					<- time.After(500 * time.Microsecond) // slow down read
 				}
-			}()*/
+			}()
 
 			buf := make([]byte, SIZE, SIZE)
 			for i := range buf {
@@ -707,7 +706,7 @@ func TestSlowReadBlocking(t *testing.T) {
 				} else if string(buf[:n]) != msg {
 					t.Fatal(err)
 				} else {
-					t.Log(stream.id, "session.bucket", atomic.LoadInt32(&session.bucket), "stream.bucket", atomic.LoadInt32(&stream.bucket))
+//					t.Log(stream.id, "session.bucket", atomic.LoadInt32(&session.bucket), "stream.bucket", atomic.LoadInt32(&stream.bucket))
 					t.Log(stream.id, i, "time for normal stream rtt", time.Since(start))
 				}
 				<- time.After(200 * time.Millisecond)

--- a/stream.go
+++ b/stream.go
@@ -332,7 +332,7 @@ func (s *Stream) returnTokens(n int) {
 
 	used := atomic.AddInt32(&s.bucket, -int32(n))
 	totalRead := atomic.AddInt32(&s.countRead, int32(n))
-	dt := time.Now().Sub(s.lastWrite)
+	dt := time.Now().Sub(s.lastWrite) + 1
 	needed := totalRead * int32(s.sess.rtt / dt)
 	atomic.StoreInt32(&s.guessNeeded, needed)
 	if used <= 0 || (needed > 0 && needed >= used) {

--- a/stream.go
+++ b/stream.go
@@ -73,8 +73,6 @@ func (s *Stream) Read(b []byte) (n int, err error) {
 
 READ:
 	select {
-	case <-s.die:
-		return 0, errors.New(errBrokenPipe)
 	case <-deadline:
 		return n, errTimeout
 	default:

--- a/stream.go
+++ b/stream.go
@@ -246,11 +246,7 @@ func (s *Stream) pushBytes(p []byte) {
 		return
 	}
 
-	if used < int32(s.sess.MaxStreamBuffer) {
-		return
-	}
-
-	if lastReadOut > (used / 2) {
+	if used < int32(s.sess.MaxStreamBuffer) || lastReadOut > (used / 2) {
 		s.boostTimeout = time.Now().Add(s.sess.BoostTimeout)
 		return
 	}

--- a/stream.go
+++ b/stream.go
@@ -275,12 +275,12 @@ func (s *Stream) markRST() {
 }
 
 // mark this stream has been pause write
-func (s *Stream) markFUL() {
+func (s *Stream) pauseWrite() {
 	atomic.StoreInt32(&s.fulflag, 1)
 }
 
 // mark this stream has been resume write
-func (s *Stream) markEMP() {
+func (s *Stream) resumeWrite() {
 	atomic.StoreInt32(&s.fulflag, 0)
 	select {
 	case s.bucketNotify <- struct{}{}:


### PR DESCRIPTION
#18 
解決一個慢的stream餓死其他stream的問題
保留原本的token來控制總buffer的使用量
除非夠慢又夠多的stream才會造成餓死的問題
(stream的MaxBuffer * N >= session的MaxBuffer)

config的預設值目前我是抓比較高, 可以看情況調整
每個Session最多16MB (MaxReceiveBuffer)
每個Stream最多16kB (MaxStreamBuffer)
Stream buffer小於4kB的時候允許對面寫入新資料 (MinStreamBuffer)
預設值能允許1024個慢速stream才會造成餓死
假設不被惡意攻擊(對面無視`cmdFUL`控制封包繼續傳)
此情況下記憶體使用量 ~= 16MB
