### PR TITLE
Fixes of issues discovered by code analysis tool

### DIFF
--- a/session.go
+++ b/session.go
@@ -118,7 +118,7 @@ func (s *Session) OpenStream() (*Stream, error) {
 func (s *Session) AcceptStream() (*Stream, error) {
 	var deadline <-chan time.Time
 	if d, ok := s.deadline.Load().(time.Time); ok && !d.IsZero() {
-		timer := time.NewTimer(d.Sub(time.Now()))
+		timer := time.NewTimer(time.Until(d))
 		defer timer.Stop()
 		deadline = timer.C
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"math/rand"
 	"net"
-	_ "net/http/pprof"
 	"strings"
 	"sync"
 	"testing"

--- a/session_test.go
+++ b/session_test.go
@@ -653,6 +653,7 @@ func getTCPConnectionPair() (net.Conn, net.Conn, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	defer lst.Close()
 
 	var conn0 net.Conn
 	var err0 error

--- a/session_test.go
+++ b/session_test.go
@@ -247,7 +247,7 @@ func TestIsClose(t *testing.T) {
 	}
 	session, _ := Client(cli, nil)
 	session.Close()
-	if session.IsClosed() != true {
+	if !session.IsClosed() {
 		t.Fatal("still open after close")
 	}
 }
@@ -272,7 +272,7 @@ func TestKeepAliveTimeout(t *testing.T) {
 	config.KeepAliveTimeout = 2 * time.Second
 	session, _ := Client(cli, config)
 	<-time.After(3 * time.Second)
-	if session.IsClosed() != true {
+	if !session.IsClosed() {
 		t.Fatal("keepalive-timeout failed")
 	}
 }

--- a/stream.go
+++ b/stream.go
@@ -46,7 +46,7 @@ func (s *Stream) ID() uint32 {
 func (s *Stream) Read(b []byte) (n int, err error) {
 	var deadline <-chan time.Time
 	if d, ok := s.readDeadline.Load().(time.Time); ok && !d.IsZero() {
-		timer := time.NewTimer(d.Sub(time.Now()))
+		timer := time.NewTimer(time.Until(d))
 		defer timer.Stop()
 		deadline = timer.C
 	}
@@ -78,7 +78,7 @@ READ:
 func (s *Stream) Write(b []byte) (n int, err error) {
 	var deadline <-chan time.Time
 	if d, ok := s.writeDeadline.Load().(time.Time); ok && !d.IsZero() {
-		timer := time.NewTimer(d.Sub(time.Now()))
+		timer := time.NewTimer(time.Until(d))
 		defer timer.Stop()
 		deadline = timer.C
 	}


### PR DESCRIPTION
Hi, thanks for the great library that's been super useful for me.

While reading the code and running the `honnef.co/go/tools/cmd/megacheck` tool on it, I found few minor issues, mostly in the tests code:

* some of the tests start child goroutines that call testing.T.Fatal method, which [must only be called from the main goroutine running test](https://golang.org/pkg/testing/#T);
* test suite relies on certain hard-coded ports which it expects to be available to bind to, this may not be the case if port is already occupied by locally running service;
* test suite seems to run a http server to expose profile endpoints with `net/http/pprof` on a fixed port, which is ineffective since this port may already be occupied and `go test` has built-in flags to directly generate profiles (`-memprofile`, `-cpuprofile`, etc.).

With my changes I tried to address these points, as well as few smaller things reported by the megacheck tool.

Please see if this is something that can be merged.