### PR TITLE
fix bug: read 0 bytes from a stream will block forever

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -44,6 +44,15 @@ func (s *Stream) ID() uint32 {
 
 // Read implements net.Conn
 func (s *Stream) Read(b []byte) (n int, err error) {
+	if len(b) == 0 {
+		select {
+		case <-s.die:
+			return 0, errors.New(errBrokenPipe)
+		default:
+			return 0, nil
+		}
+	}
+
 	var deadline <-chan time.Time
 	if d, ok := s.readDeadline.Load().(time.Time); ok && !d.IsZero() {
 		timer := time.NewTimer(time.Until(d))


### PR DESCRIPTION
从stream读取0个字节（不设置deadline），可能会引起如下问题：
1. 本次读无法返回；
2. 考虑在一个session上的许多并发的stream读取操作，其中存在一些读取0个字节的行为，可能会阻塞整个session的recvLoop，从而阻塞所有stream读操作。因为0字节的读取会抢占read event，导致非0字节的读取操作无法完成，无法归还token，token会耗尽。

参考read系统调用，如果读取0字节，可以检查底层错误。
  