### PR TITLE
Adds Session.ClosedChannel()

### DIFF
--- a/session.go
+++ b/session.go
@@ -161,6 +161,11 @@ func (s *Session) notifyBucket() {
 	}
 }
 
+// ClosedChannel returns a notification channel for session close
+func (s *Session) ClosedChannel() <-chan struct{} {
+	return s.die
+}
+
 // IsClosed does a safe check to see if we have shutdown
 func (s *Session) IsClosed() bool {
 	select {


### PR DESCRIPTION
Add the ability to watch for session closing. The only other way to do this safely would be to poll via another goroutine and call session.IsClosed(). Wich adds another goroutine stack allocation to an already goroutine heavy environment.