### PR TITLE
Expose Stream.die via Stream.GetDieCh for canceling running golang RPC func

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -86,6 +86,22 @@ func TestEcho(t *testing.T) {
 	session.Close()
 }
 
+func TestGetDieCh(t *testing.T) {
+	cs, ss, err := getSmuxStreamPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dieCh := ss.GetDieCh()
+	go func() {
+		select {
+		case <-dieCh:
+		case <-time.Tick(time.Second):
+			t.Fatal("wait die chan timeout")
+		}
+	}()
+	cs.Close()
+}
+
 func TestSpeed(t *testing.T) {
 	_, stop, cli, err := setupServer(t)
 	if err != nil {

--- a/session_test.go
+++ b/session_test.go
@@ -91,6 +91,7 @@ func TestGetDieCh(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ss.Close()
 	dieCh := ss.GetDieCh()
 	go func() {
 		select {


### PR DESCRIPTION
We are working on a Blockchain featured SQL database: [CovenantSQL](https://github.com/CovenantSQL/CovenantSQL)
Because golang `net/rpc` did not provide a context. We have no way to get notified when something happened to the underlying TCP connection to cancel a running RPC.
Thanks to `xtaci/smux`, it is possible with Stream.die exposed.