### PR TITLE
Move token to stream v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - go get github.com/xtaci/smux
 
 script:
-    - go test -coverprofile=coverage.txt -covermode=atomic -bench .
+    - go test -coverprofile=coverage.txt -covermode=atomic -bench . -v
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/frame.go
+++ b/frame.go
@@ -14,6 +14,9 @@ const ( // cmds
 	cmdFIN             // stream close, a.k.a EOF mark
 	cmdPSH             // data push
 	cmdNOP             // no operation
+	cmdACK             // for test RTT
+	cmdFUL             // buffer full
+	cmdEMP             // buffer empty
 )
 
 const (

--- a/mux.go
+++ b/mux.go
@@ -1,7 +1,6 @@
 package smux
 
 import (
-	"fmt"
 	"io"
 	"time"
 
@@ -24,15 +23,27 @@ type Config struct {
 	// MaxReceiveBuffer is used to control the maximum
 	// number of data in the buffer pool
 	MaxReceiveBuffer int
+
+	// Enable Stream buffer
+	EnableStreamBuffer bool
+
+	// maximum bytes that each Stream can use
+	MaxStreamBuffer int
+
+	// for initial boost
+	BoostTimeout time.Duration
 }
 
 // DefaultConfig is used to return a default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		KeepAliveInterval: 10 * time.Second,
-		KeepAliveTimeout:  30 * time.Second,
-		MaxFrameSize:      32768,
-		MaxReceiveBuffer:  4194304,
+		KeepAliveInterval:  2500 * time.Millisecond,
+		KeepAliveTimeout:   7500 * time.Millisecond, // RTT usually < 7500ms
+		MaxFrameSize:       32768,
+		MaxReceiveBuffer:   16 * 1024 * 1024,
+		EnableStreamBuffer: true,
+		MaxStreamBuffer:    8 * 1024 * 1024,
+		BoostTimeout:       10 * time.Second,
 	}
 }
 
@@ -40,9 +51,6 @@ func DefaultConfig() *Config {
 func VerifyConfig(config *Config) error {
 	if config.KeepAliveInterval == 0 {
 		return errors.New("keep-alive interval must be positive")
-	}
-	if config.KeepAliveTimeout < config.KeepAliveInterval {
-		return fmt.Errorf("keep-alive timeout must be larger than keep-alive interval")
 	}
 	if config.MaxFrameSize <= 0 {
 		return errors.New("max frame size must be positive")
@@ -52,6 +60,9 @@ func VerifyConfig(config *Config) error {
 	}
 	if config.MaxReceiveBuffer <= 0 {
 		return errors.New("max receive buffer must be positive")
+	}
+	if config.MaxStreamBuffer <= 0 {
+		return errors.New("max stream receive buffer must be positive")
 	}
 	return nil
 }

--- a/mux.go
+++ b/mux.go
@@ -40,9 +40,9 @@ func DefaultConfig() *Config {
 		KeepAliveInterval:  2500 * time.Millisecond,
 		KeepAliveTimeout:   7500 * time.Millisecond, // RTT usually < 7500ms
 		MaxFrameSize:       32768,
-		MaxReceiveBuffer:   16 * 1024 * 1024,
+		MaxReceiveBuffer:   4 * 1024 * 1024,
 		EnableStreamBuffer: true,
-		MaxStreamBuffer:    8 * 1024 * 1024,
+		MaxStreamBuffer:    200 * 8 * 1024,
 		BoostTimeout:       10 * time.Second,
 	}
 }

--- a/mux_test.go
+++ b/mux_test.go
@@ -26,15 +26,6 @@ func TestConfig(t *testing.T) {
 	}
 
 	config = DefaultConfig()
-	config.KeepAliveInterval = 10
-	config.KeepAliveTimeout = 5
-	err = VerifyConfig(config)
-	t.Log(err)
-	if err == nil {
-		t.Fatal(err)
-	}
-
-	config = DefaultConfig()
 	config.MaxFrameSize = 0
 	err = VerifyConfig(config)
 	t.Log(err)

--- a/session.go
+++ b/session.go
@@ -312,8 +312,7 @@ func (s *Session) recvLoop() {
 					s.gotACK <- struct{}{}
 				}
 			default:
-				s.Close()
-				return
+				// nop, for random noise or new feature cmd ID
 			}
 		} else {
 			s.Close()

--- a/session_test.go
+++ b/session_test.go
@@ -468,7 +468,6 @@ func testKeepAliveBlockWriteTimeout(t *testing.T, cli net.Conn) {
 	config.KeepAliveTimeout = 2 * time.Second
 	session, _ := Client(blockWriteCli, config)
 	time.Sleep(3 * time.Second)
-	//time.Sleep(time.Hour * 2)
 	if !session.IsClosed() {
 		t.Fatal("keepalive-timeout failed")
 	}


### PR DESCRIPTION
接續 #19 
重新提交PR
`TestSlowReadBlocking()`這個test可以復現 #18

用`net.Pipe()`測試過程中有踩到類似 #37 的問題
發送`cmdACK`跟`cmdFUL`會卡住(已透過另外開個控制包專用channel解決)
有空再試試可否透過test復現

另外改變了keepalive的實作方式
最明顯的改變是KeepAliveInterval可以大於KeepAliveTimeout
送一個包會等KeepAliveTimeout的長度再去確認無回應才斷線
如果回應在timeout之前收到
則會重設timeout跟下次發包的時機
換句話說
ping的時間點不再是固定的KeepAliveInterval
而是KeepAliveInterval + RTT

收到不明的cmd ID不再強制斷線
可以直接於SMUX這層加入雜訊且不干擾stream token的估測
或者提高之後如果引入新ID的相容性
