### PR TITLE
Close session when seeing any session level errors

### DIFF
--- a/session.go
+++ b/session.go
@@ -293,6 +293,7 @@ func (s *Session) notifyReadError(err error) {
 		s.socketReadError.Store(err)
 		close(s.chSocketReadError)
 	})
+	s.Close()
 }
 
 func (s *Session) notifyWriteError(err error) {
@@ -300,6 +301,7 @@ func (s *Session) notifyWriteError(err error) {
 		s.socketWriteError.Store(err)
 		close(s.chSocketWriteError)
 	})
+	s.Close()
 }
 
 func (s *Session) notifyProtoError(err error) {
@@ -307,6 +309,7 @@ func (s *Session) notifyProtoError(err error) {
 		s.protoError.Store(err)
 		close(s.chProtoError)
 	})
+	s.Close()
 }
 
 // IsClosed does a safe check to see if we have shutdown


### PR DESCRIPTION
So the caller can notice it when opening new streams or via the
GetDieCh, then have the opportunity to dial new sessions, or the session
can enter into a weird state, see
https://github.com/xtaci/smux/issues/61