### PR TITLE
add ability to turn off keepalive

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -17,6 +17,9 @@ type Config struct {
 	// SMUX Protocol version, support 1,2
 	Version int
 
+	// Disabled keepalive
+	KeepAliveDisabled bool
+
 	// KeepAliveInterval is how often to send a NOP command to the remote
 	KeepAliveInterval time.Duration
 
@@ -54,11 +57,13 @@ func VerifyConfig(config *Config) error {
 	if !(config.Version == 1 || config.Version == 2) {
 		return errors.New("unsupported protocol version")
 	}
-	if config.KeepAliveInterval == 0 {
-		return errors.New("keep-alive interval must be positive")
-	}
-	if config.KeepAliveTimeout < config.KeepAliveInterval {
-		return fmt.Errorf("keep-alive timeout must be larger than keep-alive interval")
+	if !config.KeepAliveDisabled {
+		if config.KeepAliveInterval == 0 {
+			return errors.New("keep-alive interval must be positive")
+		}
+		if config.KeepAliveTimeout < config.KeepAliveInterval {
+			return fmt.Errorf("keep-alive timeout must be larger than keep-alive interval")
+		}
 	}
 	if config.MaxFrameSize <= 0 {
 		return errors.New("max frame size must be positive")

--- a/session.go
+++ b/session.go
@@ -104,7 +104,9 @@ func newSession(config *Config, conn io.ReadWriteCloser, client bool) *Session {
 	go s.shaperLoop()
 	go s.recvLoop()
 	go s.sendLoop()
-	go s.keepalive()
+	if !config.KeepAliveDisabled {
+		go s.keepalive()
+	}
 	return s
 }
 


### PR DESCRIPTION
Added ability to turn off keepalive in settings.

It's need to be optional, because in some cases it's better to use TCP Keepalive. 

For example in my case when i handling 150-200k alive connections, GC begins to spend resources on the cleaning timers from smux keepalive. And enabling TCP keepalive help to me to reduce GC spend time