### PR TITLE
add more test and fix write only stream cause session bucket exhausted if MaxReceiveBuffer <= initialPeerWindow

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -56,7 +56,10 @@ func newStream(id uint32, frameSize int, sess *Session) *Stream {
 	s.sess = sess
 	s.die = make(chan struct{})
 	s.chFinEvent = make(chan struct{})
-	s.peerWindow = initialPeerWindow // set to initial window size
+	s.peerWindow = initialPeerWindow                             // set to initial window size
+	if uint32(sess.config.MaxStreamBuffer) < initialPeerWindow { // avoid write only cause session bucket exhausted
+		s.peerWindow = uint32(sess.config.MaxStreamBuffer)
+	}
 	return s
 }
 


### PR DESCRIPTION
as title,
when:
1. MaxReceiveBuffer <= initialPeerWindow
2. stream keep writing at A side
3. stream did not read at B side

the session bucket will exhausted