### PR TITLE
Add CloseChan function to session module

### DIFF
--- a/session.go
+++ b/session.go
@@ -207,6 +207,12 @@ func (s *Session) Close() error {
 	}
 }
 
+// CloseChan can be used by someone who wants to be notified immediately when this
+// session is closed
+func (s *Session) CloseChan() <-chan struct{} {
+	return s.die
+}
+
 // notifyBucket notifies recvLoop that bucket is available
 func (s *Session) notifyBucket() {
 	select {


### PR DESCRIPTION
In this commit a `CloseChan` function is added to session module.

By using this function, one can be notified immediately when a session is closed.