### PR TITLE
ErrTimeout should implement the net.Error interface

### DIFF
--- a/session.go
+++ b/session.go
@@ -47,12 +47,24 @@ const (
 	CLSDATA
 )
 
+// timeoutError representing timeouts for operations such as accept, read and write
+//
+// To better cooperate with the standard library, timeoutError should implement the standard library's `net.Error`.
+//
+// For example, using smux to implement net.Listener and work with http.Server, the keep-alive connection (*smux.Stream) will be unexpectedly closed.
+// For more details, see https://github.com/xtaci/smux/pull/99.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "timeout" }
+func (timeoutError) Temporary() bool { return true }
+func (timeoutError) Timeout() bool   { return true }
+
 var (
-	ErrInvalidProtocol = errors.New("invalid protocol")
-	ErrConsumed        = errors.New("peer consumed more than sent")
-	ErrGoAway          = errors.New("stream id overflows, should start a new connection")
-	ErrTimeout         = errors.New("timeout")
-	ErrWouldBlock      = errors.New("operation would block on IO")
+	ErrInvalidProtocol           = errors.New("invalid protocol")
+	ErrConsumed                  = errors.New("peer consumed more than sent")
+	ErrGoAway                    = errors.New("stream id overflows, should start a new connection")
+	ErrTimeout         net.Error = &timeoutError{}
+	ErrWouldBlock                = errors.New("operation would block on IO")
 )
 
 type writeRequest struct {


### PR DESCRIPTION
`ErrTimeout` 应该实现标准库的`net.Error`以便于更好的和标准库合作。

当我使用 `smux` 实现 `net.Listener` 后，和 `http.Server` 合作时，出现长连接（*smux.Stream）意外关闭的情况。
经过调试发现是这块代码和 smux 不能很好的配合：

https://github.com/golang/go/blob/8b51146c698bcfcc2c2b73fa9390db5230f2ce0a/src/net/http/server.go#L689-L741

当其它  `goroutine`  调用  `func (cr *connReader) abortPendingRead` 后，由于 `cr.conn.rwc.SetReadDeadline(aLongTimeAgo)` 会终止所有的 `Read goroutine` 包括`func (cr *connReader) backgroundRead()`
https://github.com/golang/go/blob/8b51146c698bcfcc2c2b73fa9390db5230f2ce0a/src/net/http/server.go#L717-L722
上面这段逻辑会因为 ErrTimeout 未实现 net.Error 而执行 `cr.handleReadError(err)` 导致 *smux.Stream 意外关闭。
