### PR TITLE
fix: memory leak

### DIFF
--- a/session.go
+++ b/session.go
@@ -576,7 +576,10 @@ func (s *Session) sendLoop() {
 // writeControlFrame writes the control frame to the underlying connection
 // and returns the number of bytes written if successful
 func (s *Session) writeControlFrame(f Frame) (n int, err error) {
-	return s.writeFrameInternal(f, time.After(openCloseTimeout), CLSCTRL)
+	timer := time.NewTimer(openCloseTimeout)
+	defer timer.Stop()
+
+	return s.writeFrameInternal(f, timer.C, CLSCTRL)
 }
 
 // internal writeFrame version to support deadline used in keepalive

--- a/session_test.go
+++ b/session_test.go
@@ -892,7 +892,11 @@ func TestWriteFrameInternal(t *testing.T) {
 	session.Close()
 	for i := 0; i < 100; i++ {
 		f := newFrame(1, byte(rand.Uint32()), rand.Uint32())
-		session.writeFrameInternal(f, time.After(session.config.KeepAliveTimeout), CLSDATA)
+
+		timer := time.NewTimer(session.config.KeepAliveTimeout)
+		defer timer.Stop()
+
+		session.writeFrameInternal(f, timer.C, CLSDATA)
 	}
 
 	// random cmds
@@ -904,7 +908,11 @@ func TestWriteFrameInternal(t *testing.T) {
 	session, _ = Client(cli, nil)
 	for i := 0; i < 100; i++ {
 		f := newFrame(1, allcmds[rand.Int()%len(allcmds)], rand.Uint32())
-		session.writeFrameInternal(f, time.After(session.config.KeepAliveTimeout), CLSDATA)
+
+		timer := time.NewTimer(session.config.KeepAliveTimeout)
+		defer timer.Stop()
+
+		session.writeFrameInternal(f, timer.C, CLSDATA)
 	}
 	//deadline occur
 	{

--- a/stream.go
+++ b/stream.go
@@ -494,7 +494,11 @@ func (s *stream) Close() error {
 	if once {
 		// send FIN in order
 		f := newFrame(byte(s.sess.config.Version), cmdFIN, s.id)
-		_, err = s.sess.writeFrameInternal(f, time.After(openCloseTimeout), CLSDATA)
+
+		timer := time.NewTimer(openCloseTimeout)
+		defer timer.Stop()
+
+		_, err = s.sess.writeFrameInternal(f, timer.C, CLSDATA)
 		s.sess.streamClosed(s.id)
 		return err
 	} else {


### PR DESCRIPTION
```
// Before Go 1.23, this documentation warned that the underlying
// [Timer] would not be recovered by the garbage collector until the
// timer fired, and that if efficiency was a concern, code should use
// NewTimer instead and call [Timer.Stop] if the timer is no longer needed.
// As of Go 1.23, the garbage collector can recover unreferenced,
// unstopped timers. There is no reason to prefer NewTimer when After will do.
```