### PR TITLE
allocator optimization: avoid tmp obj's allocation and gc

### DIFF
--- a/alloc.go
+++ b/alloc.go
@@ -50,34 +50,41 @@ func NewAllocator() *Allocator {
 	for k := range alloc.buffers {
 		i := k
 		alloc.buffers[k].New = func() interface{} {
-			return make([]byte, 1<<uint32(i))
+			b := make([]byte, 1<<uint32(i))
+			return &b
 		}
 	}
 	return alloc
 }
 
 // Get a []byte from pool with most appropriate cap
-func (alloc *Allocator) Get(size int) []byte {
+func (alloc *Allocator) Get(size int) *[]byte {
 	if size <= 0 || size > 65536 {
 		return nil
 	}
 
 	bits := msb(size)
 	if size == 1<<bits {
-		return alloc.buffers[bits].Get().([]byte)[:size]
-	} else {
-		return alloc.buffers[bits+1].Get().([]byte)[:size]
+		p := alloc.buffers[bits].Get().(*[]byte)
+		*p = (*p)[:size]
+		return p
 	}
+	p := alloc.buffers[bits+1].Get().(*[]byte)
+	*p = (*p)[:size]
+	return p
 }
 
 // Put returns a []byte to pool for future use,
 // which the cap must be exactly 2^n
-func (alloc *Allocator) Put(buf []byte) error {
-	bits := msb(cap(buf))
-	if cap(buf) == 0 || cap(buf) > 65536 || cap(buf) != 1<<bits {
+func (alloc *Allocator) Put(p *[]byte) error {
+	if p == nil {
 		return errors.New("allocator Put() incorrect buffer size")
 	}
-	alloc.buffers[bits].Put(buf)
+	bits := msb(cap(*p))
+	if cap(*p) == 0 || cap(*p) > 65536 || cap(*p) != 1<<bits {
+		return errors.New("allocator Put() incorrect buffer size")
+	}
+	alloc.buffers[bits].Put(p)
 	return nil
 }
 

--- a/alloc_test.go
+++ b/alloc_test.go
@@ -32,25 +32,25 @@ func TestAllocGet(t *testing.T) {
 	if alloc.Get(0) != nil {
 		t.Fatal(0)
 	}
-	if len(alloc.Get(1)) != 1 {
+	if len(*alloc.Get(1)) != 1 {
 		t.Fatal(1)
 	}
-	if len(alloc.Get(2)) != 2 {
+	if len(*alloc.Get(2)) != 2 {
 		t.Fatal(2)
 	}
-	if len(alloc.Get(3)) != 3 || cap(alloc.Get(3)) != 4 {
+	if len(*alloc.Get(3)) != 3 || cap(*alloc.Get(3)) != 4 {
 		t.Fatal(3)
 	}
-	if len(alloc.Get(4)) != 4 {
+	if len(*alloc.Get(4)) != 4 {
 		t.Fatal(4)
 	}
-	if len(alloc.Get(1023)) != 1023 || cap(alloc.Get(1023)) != 1024 {
+	if len(*alloc.Get(1023)) != 1023 || cap(*alloc.Get(1023)) != 1024 {
 		t.Fatal(1023)
 	}
-	if len(alloc.Get(1024)) != 1024 {
+	if len(*alloc.Get(1024)) != 1024 {
 		t.Fatal(1024)
 	}
-	if len(alloc.Get(65536)) != 65536 {
+	if len(*alloc.Get(65536)) != 65536 {
 		t.Fatal(65536)
 	}
 	if alloc.Get(65537) != nil {
@@ -63,19 +63,24 @@ func TestAllocPut(t *testing.T) {
 	if err := alloc.Put(nil); err == nil {
 		t.Fatal("put nil misbehavior")
 	}
-	if err := alloc.Put(make([]byte, 3, 3)); err == nil {
+	b := make([]byte, 3)
+	if err := alloc.Put(&b); err == nil {
 		t.Fatal("put elem:3 []bytes misbehavior")
 	}
-	if err := alloc.Put(make([]byte, 4, 4)); err != nil {
+	b = make([]byte, 4)
+	if err := alloc.Put(&b); err != nil {
 		t.Fatal("put elem:4 []bytes misbehavior")
 	}
-	if err := alloc.Put(make([]byte, 1023, 1024)); err != nil {
+	b = make([]byte, 1023, 1024)
+	if err := alloc.Put(&b); err != nil {
 		t.Fatal("put elem:1024 []bytes misbehavior")
 	}
-	if err := alloc.Put(make([]byte, 65536, 65536)); err != nil {
+	b = make([]byte, 65536)
+	if err := alloc.Put(&b); err != nil {
 		t.Fatal("put elem:65536 []bytes misbehavior")
 	}
-	if err := alloc.Put(make([]byte, 65537, 65537)); err == nil {
+	b = make([]byte, 65537)
+	if err := alloc.Put(&b); err == nil {
 		t.Fatal("put elem:65537 []bytes misbehavior")
 	}
 }
@@ -85,7 +90,7 @@ func TestAllocPutThenGet(t *testing.T) {
 	data := alloc.Get(4)
 	alloc.Put(data)
 	newData := alloc.Get(4)
-	if cap(data) != cap(newData) {
+	if cap(*data) != cap(*newData) {
 		t.Fatal("different cap while alloc.Get()")
 	}
 }
@@ -93,5 +98,12 @@ func TestAllocPutThenGet(t *testing.T) {
 func BenchmarkMSB(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		msb(rand.Int())
+	}
+}
+
+func BenchmarkAlloc(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		pbuf := defaultAllocator.Get(i % 65536)
+		defaultAllocator.Put(pbuf)
 	}
 }

--- a/session.go
+++ b/session.go
@@ -411,17 +411,17 @@ func (s *Session) recvLoop() {
 				s.streamLock.Unlock()
 			case cmdPSH: // data frame
 				if hdr.Length() > 0 {
-					newbuf := defaultAllocator.Get(int(hdr.Length()))
-					if written, err := io.ReadFull(s.conn, newbuf); err == nil {
+					pNewbuf := defaultAllocator.Get(int(hdr.Length()))
+					if written, err := io.ReadFull(s.conn, *pNewbuf); err == nil {
 						s.streamLock.Lock()
 						if stream, ok := s.streams[sid]; ok {
-							stream.pushBytes(newbuf)
+							stream.pushBytes(pNewbuf)
 							// a stream used some token
 							atomic.AddInt32(&s.bucket, -int32(written))
 							stream.notifyReadEvent()
 						} else {
 							// data directed to a missing/closed stream, recycle the buffer immediately.
-							defaultAllocator.Put(newbuf)
+							defaultAllocator.Put(pNewbuf)
 						}
 						s.streamLock.Unlock()
 					} else {


### PR DESCRIPTION
pool处理的buffer类型由 `[]byte` 改为 `*[]byte`，避免 `[]byte` 作为函数参数时的临时对象拷贝和不必要分配、gc压力。
```golang
func get() ([]byte, uintptr) {
	b := make([]byte, 10)
	return b, uintptr(unsafe.Pointer(&b))
}
func main() {
	b, p1 := get()
	p2 := uintptr(unsafe.Pointer(&b))
	println("p1:", p1, "p2:", p2, p1 == p2)
}
```
```sh
p1: 1374390779568 p2: 1374390779664 false
```

benchmark代码:
```go
func BenchmarkAlloc(b *testing.B) {
	for i := 0; i < b.N; i++ {
		b := defaultAllocator.Get(i % 65536)
		defaultAllocator.Put(b)
	}
}

```

修改前使用 `[]byte`：
```sh
goos: darwin
goarch: arm64
pkg: github.com/xtaci/smux
cpu: Apple M4 Pro
BenchmarkAlloc-14    	62714854	        19.06 ns/op	      24 B/op	       1 allocs/op
PASS
ok  	github.com/xtaci/smux	2.349s
```

修改为 `*[]byte` 后：
```sh
goos: darwin
goarch: arm64
pkg: github.com/xtaci/smux
cpu: Apple M4 Pro
BenchmarkAlloc-14    	155811184	         7.626 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/xtaci/smux	2.376s
```

前阵子有人提到这个优化，自己的大改了一轮，相关讨论：
https://github.com/lesismal/nbio/issues/454